### PR TITLE
Fix UX error handling on low level exceptions

### DIFF
--- a/cloudscale_cli/commands/__init__.py
+++ b/cloudscale_cli/commands/__init__.py
@@ -1,7 +1,7 @@
 import sys
 import click
 import jmespath
-from cloudscale import Cloudscale, CloudscaleApiException, CloudscaleException
+from cloudscale import Cloudscale
 from ..util import to_table, to_pretty_json, tags_to_dict
 
 if sys.stdout.isatty():
@@ -23,7 +23,7 @@ class CloudscaleCommand:
                 profile=profile,
                 debug=debug
             )
-        except CloudscaleException as e:
+        except Exception as e:
             click.echo(e, err=True)
             sys.exit(1)
 
@@ -77,7 +77,7 @@ class CloudscaleCommand:
                 with Spinner(text="Querying"):
                     response = self.get_client_resource().get_all(filter_tag)
                 click.echo(self._format_output(response))
-        except CloudscaleApiException as e:
+        except Exception as e:
             click.echo(e, err=True)
             sys.exit(1)
 
@@ -86,7 +86,7 @@ class CloudscaleCommand:
             with Spinner(text=f"Querying {uuid}"):
                 response = self.get_client_resource().get_by_uuid(uuid)
             click.echo(self._format_output(response))
-        except CloudscaleApiException as e:
+        except Exception as e:
             click.echo(e, err=True)
             sys.exit(1)
 
@@ -104,7 +104,7 @@ class CloudscaleCommand:
                 click.echo(self._format_output(response))
             else:
                 return response
-        except CloudscaleApiException as e:
+        except Exception as e:
             click.echo(e, err=True)
             sys.exit(1)
 
@@ -133,7 +133,7 @@ class CloudscaleCommand:
                 )
                 response = self.get_client_resource().get_by_uuid(uuid=uuid)
             click.echo(self._format_output(response))
-        except CloudscaleApiException as e:
+        except Exception as e:
             click.echo(e, err=True)
             sys.exit(1)
 
@@ -148,7 +148,7 @@ class CloudscaleCommand:
             with Spinner(text=f"Deleting {uuid}"):
                 self.get_client_resource().delete(uuid)
             click.echo(f"{uuid} deleted!")
-        except CloudscaleApiException as e:
+        except Exception as e:
             click.echo(e, err=True)
             sys.exit(1)
 
@@ -160,6 +160,6 @@ class CloudscaleCommand:
             with Spinner(text=f"Querying {uuid}"):
                 response = self.get_client_resource().get_by_uuid(uuid)
             click.echo(self._format_output(response))
-        except CloudscaleApiException as e:
+        except Exception as e:
             click.echo(e, err=True)
             sys.exit(1)


### PR DESCRIPTION
Before:
~~~
 $ cloudscale flavor list                                                                                                                 
Traceback (most recent call last):
  File "/home/resmo/.local/pipx/venvs/cloudscale-cli/lib/python3.8/site-packages/urllib3/connection.py", line 159, in _new_conn
    conn = connection.create_connection(
  File "/home/resmo/.local/pipx/venvs/cloudscale-cli/lib/python3.8/site-packages/urllib3/util/connection.py", line 84, in create_connection
    raise err
  File "/home/resmo/.local/pipx/venvs/cloudscale-cli/lib/python3.8/site-packages/urllib3/util/connection.py", line 74, in create_connection
    sock.connect(sa)
ConnectionRefusedError: [Errno 111] Connection refused

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/resmo/.local/pipx/venvs/cloudscale-cli/lib/python3.8/site-packages/urllib3/connectionpool.py", line 670, in urlopen
    httplib_response = self._make_request(
  File "/home/resmo/.local/pipx/venvs/cloudscale-cli/lib/python3.8/site-packages/urllib3/connectionpool.py", line 381, in _make_request
    self._validate_conn(conn)
  File "/home/resmo/.local/pipx/venvs/cloudscale-cli/lib/python3.8/site-packages/urllib3/connectionpool.py", line 978, in _validate_conn
    conn.connect()
  File "/home/resmo/.local/pipx/venvs/cloudscale-cli/lib/python3.8/site-packages/urllib3/connection.py", line 309, in connect
    conn = self._new_conn()
  File "/home/resmo/.local/pipx/venvs/cloudscale-cli/lib/python3.8/site-packages/urllib3/connection.py", line 171, in _new_conn
    raise NewConnectionError(
urllib3.exceptions.NewConnectionError: <urllib3.connection.HTTPSConnection object at 0x7f455486d700>: Failed to establish a new connection: [Errno 111] Connection refused

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/resmo/.local/pipx/venvs/cloudscale-cli/lib/python3.8/site-packages/requests/adapters.py", line 439, in send
    resp = conn.urlopen(
  File "/home/resmo/.local/pipx/venvs/cloudscale-cli/lib/python3.8/site-packages/urllib3/connectionpool.py", line 726, in urlopen
    retries = retries.increment(
  File "/home/resmo/.local/pipx/venvs/cloudscale-cli/lib/python3.8/site-packages/urllib3/util/retry.py", line 439, in increment
    raise MaxRetryError(_pool, url, error or ResponseError(cause))
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='api.cloudscale.ch', port=443): Max retries exceeded with url: /v1/flavors (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7f455486d700>: Failed to establish a new connection: [Errno 111] Connection refused'))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/resmo/.local/bin/cloudscale", line 8, in <module>
    sys.exit(cli())
  File "/home/resmo/.local/pipx/venvs/cloudscale-cli/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/resmo/.local/pipx/venvs/cloudscale-cli/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/resmo/.local/pipx/venvs/cloudscale-cli/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/resmo/.local/pipx/venvs/cloudscale-cli/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/resmo/.local/pipx/venvs/cloudscale-cli/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/resmo/.local/pipx/venvs/cloudscale-cli/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/resmo/.local/pipx/venvs/cloudscale-cli/lib/python3.8/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context().obj, *args, **kwargs)
  File "/home/resmo/.local/pipx/venvs/cloudscale-cli/lib/python3.8/site-packages/cloudscale_cli/commands/flavor.py", line 19, in cmd_list
    cloudscale.cmd_list(
  File "/home/resmo/.local/pipx/venvs/cloudscale-cli/lib/python3.8/site-packages/cloudscale_cli/commands/__init__.py", line 52, in cmd_list
    response = self.get_client_resource().get_all(filter_tag)
  File "/home/resmo/.local/pipx/venvs/cloudscale-cli/lib/python3.8/site-packages/cloudscale/lib/__init__.py", line 58, in get_all
    result = self._client.get_resources(self.resource, payload=payload)
  File "/home/resmo/.local/pipx/venvs/cloudscale-cli/lib/python3.8/site-packages/cloudscale/http.py", line 84, in get_resources
    r = requests.get(query_url, headers=self.headers, timeout=self.timeout)
  File "/home/resmo/.local/pipx/venvs/cloudscale-cli/lib/python3.8/site-packages/requests/api.py", line 76, in get
    return request('get', url, params=params, **kwargs)
  File "/home/resmo/.local/pipx/venvs/cloudscale-cli/lib/python3.8/site-packages/requests/api.py", line 61, in request
    return session.request(method=method, url=url, **kwargs)
  File "/home/resmo/.local/pipx/venvs/cloudscale-cli/lib/python3.8/site-packages/requests/sessions.py", line 530, in request
    resp = self.send(prep, **send_kwargs)
  File "/home/resmo/.local/pipx/venvs/cloudscale-cli/lib/python3.8/site-packages/requests/sessions.py", line 643, in send
    r = adapter.send(request, **kwargs)
  File "/home/resmo/.local/pipx/venvs/cloudscale-cli/lib/python3.8/site-packages/requests/adapters.py", line 516, in send
    raise ConnectionError(e, request=request)
requests.exceptions.ConnectionError: HTTPSConnectionPool(host='api.cloudscale.ch', port=443): Max retries exceeded with url: /v1/flavors (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7f455486d700>: Failed to establish a new connection: [Errno 111] Connection refused'))
~~~

After:
~~~
 $ cloudscale floating-ip list                                                                                                 
HTTPSConnectionPool(host='api.cloudscale.ch', port=443): Max retries exceeded with url: /v1/floating-ips (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7f173cb6bc70>: Failed to establish a new connection: [Errno 111] Connection refused'))
