### PR TITLE
Implement natural sort table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 - cloudscale-sdk updated to 0.5.0.
 - Add option `--detach` for volumes to detach.
+- Add natural sort for table output.
 
 ## v1.0.1 (2020-10-09)
 

--- a/cloudscale_cli/commands/region.py
+++ b/cloudscale_cli/commands/region.py
@@ -8,6 +8,7 @@ def region(ctx):
         'slug',
         'zones',
     ]
+    ctx.obj.resource_table_sort_key = 'slug'
 
 @click.option('--filter-json')
 @region.command("list")

--- a/cloudscale_cli/commands/server_group.py
+++ b/cloudscale_cli/commands/server_group.py
@@ -12,6 +12,16 @@ def server_group(ctx):
         'tags',
         'uuid',
     ]
+    ctx.obj.response_transform_json = '''
+        [].{
+            "name": name,
+            "type": type,
+            "servers": servers,
+            "zone": zone.slug,
+            "tags": tags,
+            "uuid": uuid
+            }
+    '''
 
 @click.option('--filter-tag')
 @click.option('--filter-json')

--- a/cloudscale_cli/commands/subnet.py
+++ b/cloudscale_cli/commands/subnet.py
@@ -13,6 +13,7 @@ def subnet(ctx):
         'tags',
     ]
     ctx.obj.resource_name_key = None
+    ctx.obj.resource_table_sort_key = 'cidr'
 
 @click.option('--filter-tag')
 @click.option('--filter-json')

--- a/cloudscale_cli/commands/volume.py
+++ b/cloudscale_cli/commands/volume.py
@@ -14,6 +14,16 @@ def volume(ctx):
         'server_uuids',
         'uuid',
     ]
+    ctx.obj.response_transform_json = '''
+        [].{
+            "name": name,
+            "type": type,
+            "tags": tags,
+            "server_uuids": server_uuids,
+            "zone": zone.slug,
+            "uuid": uuid
+            }
+    '''
 
 @click.option('--filter-tag')
 @click.option('--filter-json')

--- a/cloudscale_cli/util.py
+++ b/cloudscale_cli/util.py
@@ -1,9 +1,9 @@
 import json
+import jmespath
 from click import Group
 from collections import OrderedDict
 from tabulate import tabulate
 from pygments import highlight, lexers, formatters
-import jmespath
 
 
 class OrderedGroup(Group):
@@ -19,13 +19,15 @@ class OrderedGroup(Group):
         return sorted(self.commands.keys())
 
 
+def format_json(data: list, format_json: str = None) -> list:
+    if format_json:
+        data = jmespath.search(format_json, data)
+    return data
+
 def to_table(data: list, headers: list, format_json: str = None) -> str:
     '''
     Turn a list into a table
     '''
-
-    if format_json:
-        data = jmespath.search(format_json, data)
 
     formated_headers = []
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ tabulate
 pygments
 jmespath
 yaspin
+natsort


### PR DESCRIPTION
How it is returned by the API:
```
 $ cloudscale server list
NAME         STATUS    ZONE    TAGS    UUID
-----------  --------  ------  ------  ------------------------------------
ubuntU-2001  running   lpg1            755044bd-6fc4-4b6b-8dc5-4e4f21cc64c7
ubuntU-2005  running   lpg1            94c10d78-755d-4eea-8946-e7443232d051
ubuntu-2005  running   rma1            286525b3-15fa-48e8-948b-71f4dee86324
ubuntu-2002  running   rma1            4805447b-2d38-4eed-8384-b219c1b794ec
ubuntu-2003  running   lpg1            2b6bca3a-1ad6-411b-b7fe-0d1158d4f9af
ubuntu-2004  running   lpg1            e7aa78be-2f9a-4aa0-b48f-e03549fd49ad
```
with natural sort (zone, name):

```
 $ cloudscale server list                     
NAME         STATUS    ZONE    TAGS    UUID
-----------  --------  ------  ------  ------------------------------------
ubuntU-2001  running   lpg1            755044bd-6fc4-4b6b-8dc5-4e4f21cc64c7
ubuntu-2003  running   lpg1            2b6bca3a-1ad6-411b-b7fe-0d1158d4f9af
ubuntu-2004  running   lpg1            e7aa78be-2f9a-4aa0-b48f-e03549fd49ad
ubuntU-2005  running   lpg1            94c10d78-755d-4eea-8946-e7443232d051
ubuntu-2002  running   rma1            4805447b-2d38-4eed-8384-b219c1b794ec
ubuntu-2005  running   rma1            286525b3-15fa-48e8-948b-71f4dee86324

```
