### PR TITLE
fix: Allow uploading custom images as qcow2

### DIFF
--- a/cloudscale_cli/commands/custom_image.py
+++ b/cloudscale_cli/commands/custom_image.py
@@ -80,7 +80,7 @@ def cmd_show(cloudscale, uuid):
 )
 @click.option("--zone", "zones", multiple=True, required=True)
 @click.option(
-    "--source-format", type=click.Choice(["raw"]), default="raw", show_default=True
+    "--source-format", type=click.Choice(["raw", "qcow2"]), default="raw", show_default=True
 )
 @click.option("--tag", "tags", multiple=True)
 @click.option("--wait", is_flag=True)


### PR DESCRIPTION
qcow2 is supported again since 2024-07-31.
(https://www.cloudscale.ch/en/news/2024/07/31/securing-qcow2-image-imports)